### PR TITLE
fix ** (Enum.EmptyError) empty error

### DIFF
--- a/lib/io/export.ex
+++ b/lib/io/export.ex
@@ -136,8 +136,8 @@ defmodule Plsm.IO.Export do
 
     trimmed_columns = remove_foreign_keys(table.columns, table.header.name)
 
-    max_name_wid = Enum.map(trimmed_columns, &byte_size(str(&1.name))) |> Enum.max()
-    max_type_wid = Enum.map(trimmed_columns, &byte_size(str(&1.type))) |> Enum.max()
+    max_name_wid = Enum.map(trimmed_columns, &byte_size(str(&1.name))) |> Enum.max(fn -> 0 end)
+    max_type_wid = Enum.map(trimmed_columns, &byte_size(str(&1.type))) |> Enum.max(fn -> 0 end)
 
     column_output =
       trimmed_columns


### PR DESCRIPTION
code was raising on this simple join table..

```
➜  myapp mix ecto.gen.schema -t app_user
Generated myapp app
Using default database PostgreSQL...
** (Enum.EmptyError) empty error
    (elixir 1.14.2) lib/enum.ex:1855: anonymous fn/0 in Enum.max/1
    (plsm 2.4.0) lib/io/export.ex:141: Plsm.IO.Export.prepare/3
    (plsm 2.4.0) lib/plsm.ex:53: anonymous fn/3 in Mix.Tasks.Ecto.Gen.Schema.run/1
    (elixir 1.14.2) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
    (mix 1.14.2) lib/mix/task.ex:421: anonymous fn/3 in Mix.Task.run_task/4
    (mix 1.14.2) lib/mix/cli.ex:84: Mix.CLI.run_task/2
```

after fix schema is generated correctly:

```
defmodule MyApp.AppUser do
  use    Ecto.Schema
  import Ecto.Changeset

  @primary_key false
  schema "app_user" do

    belongs_to :userId, MyApp.User, references: :id
    belongs_to :appId, MyApp.App, references: :id
  end

  def changeset(struct, params \\ %{}) do
    struct
    |> cast(params, [
      :userId, :appId
    ])
    |> validate_required([
      :userId, :appId
    ])
  end
end
```