### PR TITLE
only select "BASE TABLE" avoid VIEW tables etc

### DIFF
--- a/lib/database/postgresql.ex
+++ b/lib/database/postgresql.ex
@@ -34,7 +34,7 @@ defimpl Plsm.Database, for: Plsm.Database.PostgreSQL do
     {_, result} =
       Postgrex.query(
         db.connection,
-        "SELECT table_name FROM information_schema.tables WHERE table_schema = '#{db.schema}' and table_name != 'schema_migrations';",
+        "SELECT table_name FROM information_schema.tables WHERE table_type = 'BASE TABLE' and table_schema = '#{db.schema}' and table_name != 'schema_migrations';",
         []
       )
 


### PR DESCRIPTION
got an error due to the DB having postgis enabled and having special tables "geography_columns" and "geometry_columns" which plsm was failing on..

see https://www.postgresql.org/docs/current/infoschema-tables.html for table_type docs